### PR TITLE
🩹Fix CI setup - replace `docker-compose` with `docker compose`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         # Tokens will expire 2025-02-01
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USR }} --password-stdin
       - name: Start containers
-        run: docker-compose -f "integrationtests/docker-compose.yml" up -d
+        run: docker compose -f "integrationtests/docker-compose.yml" up -d
       - name: Run Tests and Record Coverage
         env: # this is for the tests with real oauth-checks
           AUTH0_TEST_CLIENT_ID: ${{ secrets.AUTH0_TEST_CLIENT_ID }}

--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -30,7 +30,7 @@ jobs:
         # Tokens will expire 2025-02-01
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USR }} --password-stdin
       - name: Start containers
-        run: docker-compose -f "integrationtests/docker-compose.yml" up -d
+        run: docker compose -f "integrationtests/docker-compose.yml" up -d
       - name: Run the Integration Tests via Tox
         env: # this is for the tests with real oauth-checks
           AUTH0_TEST_CLIENT_ID: ${{ secrets.AUTH0_TEST_CLIENT_ID }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,7 +41,7 @@ jobs:
         # Tokens will expire 2025-02-01
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USR }} --password-stdin
       - name: Start containers
-        run: docker-compose -f "integrationtests/docker-compose.yml" up -d
+        run: docker compose -f "integrationtests/docker-compose.yml" up -d
       - name: Run tests
         env: # this is for the tests with real oauth-checks
           AUTH0_TEST_CLIENT_ID: ${{ secrets.AUTH0_TEST_CLIENT_ID }}


### PR DESCRIPTION
### Failing CI due to `docker-compose ... command not found`

> Die Lösung ist wohl, dass man "docker compose" ohne den bindestrich verwendet.
> Und das Problem tritt dann auf, wenn man ubuntu-latest als OS der Action
> verwendet und dieses ungepinnte "latest" ein falsches latest ist.

\- @hf-kklein

*This PR was generated using [multi-gitter](https://github.com/lindell/multi-gitter)*