### PR TITLE
👷‍♂️Dependabot autoapprove: Retrigger CI and wait for tests

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,18 +1,35 @@
 name: Dependabot auto-approve / -merge
 on: pull_request
 
+permissions:
+  contents: write
+  pull-requests: write
+  # down scope as necessary via https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
+
 jobs:
   dependabot:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
-    env:
-      PR_URL: ${{github.event.pull_request.html_url}}
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     if: ${{ github.actor == 'dependabot[bot]' }}
+    env:
+      PR_URL: ${{github.event.workflow_run.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: Approve a PR
+      - uses: actions/checkout@v4
+      - name: Commit and push empty commit
+        run: |
+          git config --local user.email "dependabot_ci_retrigger@users.noreply.github.com"
+          git config --local user.name "dependabot_ci_retrigger"
+          git commit --allow-empty -m "Retrigger CI"
+          git push
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: "dependabot"
+          wait-interval: 10
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve Dependabot PR
         run: gh pr review --approve "$PR_URL"
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
+


### PR DESCRIPTION
No idea if this works. If it works, Dependabot may have problems with rebasing etc. since Dependabot only rebases existing PRs if no other commits were pushed to the branch.