### PR TITLE
chore: remove pip-compile step from tox.ini/dev commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ deps =
     pre-commit
 commands =
     python -m pip install --upgrade pip
-    pip-compile pyproject.toml
+    # pip-compile pyproject.toml
     pip install -r requirements.txt
     pre-commit install
 


### PR DESCRIPTION
with tox -e dev want to reproduce the state on github, not update anything
