### PR TITLE
feat: add PreauthorizedTransformerBeeClient for pre-set auth headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ from yarl import URL
 from transformerbeeclient import PreauthorizedTransformerBeeClient
 
 client = PreauthorizedTransformerBeeClient(
-    base_url=URL("https://transformer.utilibee.io"),
+    base_url=URL("https://transformer.utilibee.io/"),
     authorization_header="Bearer your-token-here",  # or "Basic dXNlcjpwYXNz" for Basic auth
 )
 ```
+Note: Unlike the other clients, `PreauthorizedTransformerBeeClient` requires the `base_url` to be a `yarl.URL` instance.
 This client does not manage token refresh - it uses the provided authorization header as-is.
 
 #### Minimal Working Examples

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ client = AuthenticatedTransformerBeeClient(
 )
 ```
 
+#### Pre-authorized with Existing Token
+If you already have an authorization token (e.g., from another service or a custom auth flow), you can use the `PreauthorizedTransformerBeeClient` class:
+```python
+from yarl import URL
+from transformerbeeclient import PreauthorizedTransformerBeeClient
+
+client = PreauthorizedTransformerBeeClient(
+    base_url=URL("https://transformer.utilibee.io"),
+    authorization_header="Bearer your-token-here",  # or "Basic dXNlcjpwYXNz" for Basic auth
+)
+```
+This client does not manage token refresh - it uses the provided authorization header as-is.
+
 #### Minimal Working Examples
 Find full examples of both conversions in [the integration tests](integrationtests/test_conversion.py).
 Find the respective BO4E and EDIFACTs in [the test data folder](integrationtests/TestEdifact).

--- a/integrationtests/test_conversion.py
+++ b/integrationtests/test_conversion.py
@@ -38,3 +38,17 @@ class TestConversion:
         actual = await oauthenticated_client.convert_to_edifact(boneycomb, EdifactFormatVersion.FV2310)
         assert isinstance(actual, str)
         assert actual.startswith("UNA:+.? 'UNB+UNOC:")
+
+    async def test_edifact_to_bo4e_with_preauthorized_client(self, preauthorized_client: TransformerBeeClient) -> None:
+        with open(Path(__file__).parent / "TestEdifact" / "FV2310" / "55001.edi", "r", encoding="utf-8") as edifile:
+            edifact = edifile.read()
+        actual = await preauthorized_client.convert_to_bo4e(edifact, EdifactFormatVersion.FV2310)
+        assert isinstance(actual, list)
+        assert all(isinstance(x, BOneyComb) for x in actual[0].transaktionen)
+
+    async def test_bo4e_to_edifact_with_preauthorized_client(self, preauthorized_client: TransformerBeeClient) -> None:
+        with open(Path(__file__).parent / "TestEdifact" / "FV2310" / "55001.json", "r", encoding="utf-8") as edifile:
+            boneycomb = BOneyComb.model_validate(json.load(edifile))
+        actual = await preauthorized_client.convert_to_edifact(boneycomb, EdifactFormatVersion.FV2310)
+        assert isinstance(actual, str)
+        assert actual.startswith("UNA:+.? 'UNB+UNOC:")

--- a/src/transformerbeeclient/__init__.py
+++ b/src/transformerbeeclient/__init__.py
@@ -2,7 +2,11 @@
 TransformerBeeClient is a Python client for the transformer.bee API.
 """
 
-from .client import AuthenticatedTransformerBeeClient, UnauthenticatedTransformerBeeClient
+from .client import (
+    AuthenticatedTransformerBeeClient,
+    PreauthorizedTransformerBeeClient,
+    UnauthenticatedTransformerBeeClient,
+)
 from .models.boneycomb import BOneyComb
 from .models.marktnachricht import Marktnachricht
 from .protocols import CanConvertToBo4e, CanConvertToEdifact, TransformerBeeClient
@@ -10,6 +14,7 @@ from .protocols import CanConvertToBo4e, CanConvertToEdifact, TransformerBeeClie
 __all__ = [
     "TransformerBeeClient",
     "AuthenticatedTransformerBeeClient",
+    "PreauthorizedTransformerBeeClient",
     "UnauthenticatedTransformerBeeClient",
     "BOneyComb",
     "Marktnachricht",

--- a/src/transformerbeeclient/client.py
+++ b/src/transformerbeeclient/client.py
@@ -287,15 +287,17 @@ class PreauthorizedTransformerBeeClient(
     This client does not manage token refresh - it uses the provided authorization header as-is.
     """
 
-    def __init__(self, base_url: URL | str, authorization_header: str):
+    def __init__(self, base_url: URL, authorization_header: str):
         """
         Instantiate by providing the base URL and the authorization header value
-        :param base_url: e.g. https://transformerbee.utilibee.io/ or https://localhost:5021
+        :param base_url: e.g. URL("https://transformerbee.utilibee.io/") or URL("https://localhost:5021")
         :param authorization_header: the Authorization header value, e.g. "Bearer your-token" or "Basic dXNlcjpwYXNz"
         """
+        if not isinstance(base_url, URL):
+            raise ValueError(f"Pass the base URL as yarl URL or bad things will happen. Got {base_url.__class__}")
         _ClientSessionMixin.__init__(self)
         TransformerBeeClient.__init__(self)
-        self._base_url = URL(base_url)
+        self._base_url = base_url
         self._authorization_header = authorization_header
 
     async def convert_to_bo4e(self, edifact: str, edifact_format_version: EdifactFormatVersion) -> list[Marktnachricht]:

--- a/src/transformerbeeclient/client.py
+++ b/src/transformerbeeclient/client.py
@@ -261,6 +261,22 @@ class UnauthenticatedTransformerBeeClient(
         TransformerBeeClient.__init__(self)
         self._base_url = URL(base_url)
 
+    async def convert_to_bo4e(self, edifact: str, edifact_format_version: EdifactFormatVersion) -> list[Marktnachricht]:
+        """
+        converts the given edifact to a list of marktnachrichten
+        """
+        session = await self._get_session()
+        result = await self._convert_to_bo4e(session, self._base_url, edifact, edifact_format_version)
+        return result
+
+    async def convert_to_edifact(self, boney_comb: BOneyComb, edifact_format_version: EdifactFormatVersion) -> str:
+        """
+        converts the given boneycomb to an edifact
+        """
+        session = await self._get_session()
+        result = await self._convert_to_edifact(session, self._base_url, boney_comb, edifact_format_version)
+        return result
+
 
 class PreauthorizedTransformerBeeClient(
     TransformerBeeClient, _ClientSessionMixin, _TransformerBeeClientBaseMixin

--- a/src/transformerbeeclient/client.py
+++ b/src/transformerbeeclient/client.py
@@ -289,7 +289,7 @@ class PreauthorizedTransformerBeeClient(
 
     def __init__(self, base_url: URL | str, authorization_header: str):
         """
-        instantiate by providing the base URL and the authorization header value
+        Instantiate by providing the base URL and the authorization header value
         :param base_url: e.g. https://transformerbee.utilibee.io/ or https://localhost:5021
         :param authorization_header: the Authorization header value, e.g. "Bearer your-token" or "Basic dXNlcjpwYXNz"
         """


### PR DESCRIPTION
Add a new client that accepts a pre-computed authorization header value,
useful when authentication is handled externally or tokens are obtained
from another service. Unlike AuthenticatedTransformerBeeClient, this
client does not manage token refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
